### PR TITLE
Depend on network-bsd

### DIFF
--- a/rollbar.cabal
+++ b/rollbar.cabal
@@ -27,6 +27,7 @@ library
     , resourcet
     , http-conduit
     , lifted-base
+    , network-bsd
 
   hs-source-dirs:      src
 


### PR DESCRIPTION
This module got moved out from network to network-bsd, adding this dependency will also add a lower bound to network (because network-bsd does that).